### PR TITLE
Add filter options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 
 [[package]]
 name = "stream-extractor"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "pcap-file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,15 @@
 name = "stream-extractor"
 version = "0.2.0"
 edition = "2021"
+authors = ["geno nullfree <nullfree.geno@gmail.com>"]
+license = "BSD-3-Clause"
+description = "The TCP Stream Extractor is a small utility that can read in a PCAP file, search through it for TCP streams, and write out each stream to a separate new PCAP file."
+readme = "README.md"
+homepage = "https://github.com/genonullfree/stream-extractor.git"
+repository = "https://github.com/genonullfree/stream-extractor.git"
+keywords = ["pcap", "tcp", "stream"]
+categories = ["command-line-utilities", "network-programming"]
+exclude = ["sample"]
 
 [dependencies]
 clap = { version = "4.1.8", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stream-extractor"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -39,4 +39,11 @@ To build `stream-extractor`, execute:
 cargo build
 ```
 
+## Install from cargo
+
+To build and install from `cargo`, execute:
+```bash
+cargo install stream-extractor
+```
+
 An example PCAP is located in `sample/`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,26 @@ Usage: stream-extractor [OPTIONS] --input <INPUT>
 Options:
   -i, --input <INPUT>    Input pcap file to split
   -o, --output <OUTPUT>  Output name template [default: output_]
+  -p, --port <PORT>      Filter output files to ones that contain the specified port number
+      --ip <IP>          Filter output files to ones that contain the specified IP address
   -h, --help             Print help
+```
+
+## Filter Options
+
+The filter options `--port` and `--ip` are available to allow you to only write out the detected TCP streams that match the filter values. This can help simplify
+the research step of identifying exactly which streams you may be interested in.
+
+Example:
+```bash
+stream-extractor --ip 192.168.110.10 -p 80 -i sample/test.pcap
+Packets processed: 21933, Streams detected: 662
+Filtering streams by communications including port: 80
+ + Found 3 matching streams
+Filtering streams by communications including IP address: 192.168.110.10
+ + Found 1 matching streams
+Number of streams that matched filters: 1
+Writing output file: 1
 ```
 
 ## Build

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,11 +34,11 @@ struct Opt {
     #[arg(short, long, default_value = "output_")]
     output: String,
 
-    /// Restrict output files to ones that contain the specified port number
+    /// Filter output files to ones that contain the specified port number
     #[arg(short, long)]
     port: Option<u16>,
 
-    /// Restrict output files to ones that contains the specified IP address
+    /// Filter output files to ones that contain the specified IP address
     #[arg(long)]
     ip: Option<Ipv4Addr>,
 }


### PR DESCRIPTION
Add IP and port filter options. This allows us to filter out streams we don't care about and only write out the ones that match our filter options.